### PR TITLE
fix: corrected org admins to be team maintainers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,5 +24,6 @@ resource "github_team" "all_users" {
 resource "github_team_membership" "all_users" {
   for_each = setunion(local.users, local.admins)
   username = each.key
+  role     = can(github_membership.admin[each.key]) ? "maintainer" : "member"
   team_id  = github_team.all_users.id
 }


### PR DESCRIPTION
Correction so organization admin get the role maintainer on the teams, as that seems to be the default and needed for plan to run without changes